### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ A Laravel package, that allows signing emails with DKIM.
 composer require simonschaufi/laravel-dkim
 ```
 
-After that, you should publish the config file with:
-
-```bash
-php artisan vendor:publish --provider="SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider"
-```
-
 The providers array in `config/app.php` has an entry with `Illuminate\Mail\MailServiceProvider::class`. Comment this 
 line out and add your own service provider entry (in the "Package Service Providers" section):
 
@@ -32,6 +26,12 @@ SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider::class,
 ```
 
 The DKIMMailServiceProvider extends the MailServiceProvider and overwrites a method that we need for our own behavior.
+
+After that, you should publish the config file with:
+
+```bash
+php artisan vendor:publish --provider="SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider"
+```
 
 Next we need to create a private and public key pair for signing and verifying the email.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The DKIMMailServiceProvider extends the MailServiceProvider and overwrites a met
 After that, you should publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider"
+php artisan vendor:publish --provider="SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider" --tag dkim-config
 ```
 
 Next we need to create a private and public key pair for signing and verifying the email.


### PR DESCRIPTION
Thank you for creating this package! :pray: 

This PR changes two things in the installation instructions of the `README.md`.

First, publishing the package config only works once the service provider is registered. Otherwise the service provider class is not found and nothing gets published. That's why I switched the steps around.

Second, running `php artisan vendor:publish --provider="SimonSchaufi\LaravelDKIM\DKIMMailServiceProvider"` will publish *all* assets of that service provider. Since this package's `DKIMMailServiceProvider` extends `Illuminate\Mail\MailServiceProvider`, the assets of the base class will also be published. This includes default views and resources which are usually not needed when installing this package. I am pretty sure that this is what happened here: https://github.com/simonschaufi/laravel-dkim/discussions/5
Therefore I added `--tag dkim-config` to the command as a filter, so only the `config/dkim.php` will be published.