### PR TITLE
Disable DKIM signing if no domain is set

### DIFF
--- a/src/DKIMMailServiceProvider.php
+++ b/src/DKIMMailServiceProvider.php
@@ -35,7 +35,10 @@ class DKIMMailServiceProvider extends MailServiceProvider
     protected function registerIlluminateMailer()
     {
         $this->app->singleton('mail.manager', static function (Application $app) {
-            return new MailManager($app);
+            if (config('dkim.domain') !== null) {
+                return new MailManager($app);
+            }
+            return new \Illuminate\Mail\MailManager($app);
         });
 
         $this->app->bind('mailer', static function (Application $app) {

--- a/src/DKIMMailServiceProvider.php
+++ b/src/DKIMMailServiceProvider.php
@@ -35,10 +35,10 @@ class DKIMMailServiceProvider extends MailServiceProvider
     protected function registerIlluminateMailer()
     {
         $this->app->singleton('mail.manager', static function (Application $app) {
-            if (config('dkim.domain') !== null) {
-                return new MailManager($app);
+            if (config('dkim.domain') === null) {
+                return new \Illuminate\Mail\MailManager($app);
             }
-            return new \Illuminate\Mail\MailManager($app);
+            return new MailManager($app);
         });
 
         $this->app->bind('mailer', static function (Application $app) {


### PR DESCRIPTION
Thank you for creating this package! 🙏

When using this package and replacing Laravel's `MailServiceProvider`, an error is thrown when DKIM is not set up properly.
Our code runs in two environments. One environment requires DKIM-signed mails from the application. This works nicely with this package. The second environment uses an internal SMTP relay which signs outgoing mails with DKIM for us - we don't have access to the DKIM keys there. In this case, I'd like to disable DKIM signing.

One possible workaround is that this package "deactivates" itself if no `dkim.domain` is configured - in that case, the default `\Illuminate\Mail\MailManager` is registered. This is what I've implemented in this small PR.

What do you think? Is there another good way to accomplish this? I also thought about adding an extra `dkim.enabled` config entry, but I think if the domain is not set (and there is no default), no valid signature can be produced anyways.

My proposed changes would be a breaking change: If `dkim.domain` is not set, an error was thrown and no mail was sent; now, the mail is sent without DKIM signature.