### PR TITLE
Guess dkim domain automatically

### DIFF
--- a/config/dkim.php
+++ b/config/dkim.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 return [
+    'enabled' => env('DKIM_ENABLED', true),
     'private_key' => env('DKIM_PRIVATE_KEY', storage_path('app/dkim/private_key.txt')),
     'selector' => env('DKIM_SELECTOR', 'default'),
-    'domain' => env('DKIM_DOMAIN', null),
+    'domain' => env('DKIM_DOMAIN', parse_url(config('app.url'))['host']),
     'passphrase' => env('DKIM_PASSPHRASE', ''),
     'algorithm' => env('DKIM_ALGORITHM', 'rsa-sha256'),
     'identity' => env('DKIM_IDENTITY', null),

--- a/src/DKIMMailServiceProvider.php
+++ b/src/DKIMMailServiceProvider.php
@@ -37,9 +37,8 @@ class DKIMMailServiceProvider extends MailServiceProvider
         $this->app->singleton('mail.manager', static function (Application $app) {
             if (config('dkim.enabled', true) && config('dkim.domain') !== null) {
                 return new MailManager($app);
-            } else {
-                return new \Illuminate\Mail\MailManager($app);
             }
+            return new \Illuminate\Mail\MailManager($app);
         });
 
         $this->app->bind('mailer', static function (Application $app) {

--- a/src/DKIMMailServiceProvider.php
+++ b/src/DKIMMailServiceProvider.php
@@ -35,10 +35,11 @@ class DKIMMailServiceProvider extends MailServiceProvider
     protected function registerIlluminateMailer()
     {
         $this->app->singleton('mail.manager', static function (Application $app) {
-            if (config('dkim.domain') === null) {
+            if (config('dkim.enabled', true) && config('dkim.domain') !== null) {
+                return new MailManager($app);
+            } else {
                 return new \Illuminate\Mail\MailManager($app);
             }
-            return new MailManager($app);
         });
 
         $this->app->bind('mailer', static function (Application $app) {


### PR DESCRIPTION
This is just a suggestion, but in 99 % of cases, the DKIM domain could be guessed by the value of `app.url` and wouldn't need to be set manually. Even if many users would need to override this, having a sensible default wouldn't hurt.  I also added `DKIM_ENABLED` to have a more explicit way of enabling and disabling the DKIM signing.

`dkim.enabled` should probably be `false` by default, but implementing it this way ensures backwards compatibility. If you prefer a clean, breaking change, that could be adapted very easily.