### PR TITLE
Make sure return type is in sync with overriden implementation

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -19,7 +19,7 @@ class Mailer extends \Illuminate\Mail\Mailer
      * @param  \Closure|string|null  $callback
      * @return SentMessage|null
      */
-    public function send($view, array $data = [], $callback = null): ?SentMessage
+    public function send($view, array $data = [], $callback = null)
     {
         if ($view instanceof MailableContract) {
             return $this->sendMailable($view);


### PR DESCRIPTION
The return type must not be typechecked because this method actually can also return int if a `Illuminate\Contracts\Mail\Mailable` that implements `Illuminate\Contracts\Queue\ShouldQueue` is passed to it.